### PR TITLE
Disable canvas selection

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -22,6 +22,12 @@ body {
 }
 
 canvas {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 input[type="range"] {


### PR DESCRIPTION
I noticed that with the first ellipse example the canvas is selectable, which gives the user big (blue) selection boxes when they click quickly. It feels like this can easily be solved with `user-select: none;` rules on the canvas's. 
See: http://stackoverflow.com/questions/826782/css-rule-to-disable-text-selection-highlighting
