### PR TITLE
Update sketch.js

### DIFF
--- a/demos/flocking/sketch.js
+++ b/demos/flocking/sketch.js
@@ -152,7 +152,7 @@ var flockingSketch = function( sketch ) {
 
   sketch.getWeather = function() {
     console.log("Get Weather");
-    var url = 'http://api.openweathermap.org/data/2.5/weather?q=New%20York,NY&units=imperial&APPID=7bbbb47522848e8b9c26ba35c226c734';
+    var url = 'http://api.openweathermap.org/data/2.5/weather?q=New%20York,US&units=imperial&APPID=7bbbb47522848e8b9c26ba35c226c734';
     sketch.loadJSON(url, sketch.gotWeather);
   }
 


### PR DESCRIPTION
The query "New%20York,NY" returns 404, and results in the weather-related parts not working in the  video's flocking demo. Perhaps OpenWeatherMap's labeling scheme has changed? Querying "New%20York,US" gives the expected result.