### PR TITLE
fix weather display (HTTP => HTTPS)

### DIFF
--- a/demos/flocking/sketch.js
+++ b/demos/flocking/sketch.js
@@ -152,7 +152,7 @@ var flockingSketch = function( sketch ) {
 
   sketch.getWeather = function() {
     console.log("Get Weather");
-    var url = 'http://api.openweathermap.org/data/2.5/weather?q=New%20York,US&units=imperial&APPID=7bbbb47522848e8b9c26ba35c226c734';
+    var url = 'https://api.openweathermap.org/data/2.5/weather?q=New%20York,US&units=imperial&APPID=7bbbb47522848e8b9c26ba35c226c734';
     sketch.loadJSON(url, sketch.gotWeather);
   }
 


### PR DESCRIPTION
On Chrome, at least, the weather display doesn't work. Instead, I get a mixed-content error:

> Mixed Content: The page at 'https://hello.p5js.org/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.openweathermap.org/data/2.5/weather?q=New%20York,US&units=imperial&APPID=7bbbb47522848e8b9c26ba35c226c734'. This request has been blocked; the content must be served over HTTPS.

It looks like this API is available over HTTPS, so this might fix that. (TBH, I haven't tested it...)

Thanks so much!